### PR TITLE
Add BibDate parsing

### DIFF
--- a/app/graphql/types/date.rb
+++ b/app/graphql/types/date.rb
@@ -1,4 +1,6 @@
 class Types::Date < Types::BaseObject
   field :type, String, null: true
   field :on, String, null: true
+  field :from, String, null: true
+  field :to, String, null: true
 end


### PR DESCRIPTION
```GraphQL
fragment DateFields on BibDate { from, to, on, type }

{
  documents(type: "csd-standard", limit: 1) {
    id
    type
    bibdata {
      date {
        ...DateFields
      }
    }

  }
}
```

Response:

```GraphQL
{
  "data": {
    "documents": [
      {
        "id": "cc-0707",
        "type": "csd-standard",
        "bibdata": {
          "date": {
            "from": null,
            "to": null,
            "on": "2007-10-04",
            "type": "published"
          }
        }
      }
    ]
  }
}
```