### PR TITLE
Parse nested elements under bibdata element

### DIFF
--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -2,5 +2,10 @@ require "graphql"
 
 module Types
   class BaseObject < GraphQL::Schema::Object
+    private
+
+    def ensure_array_type(data)
+      data.is_a?(Array) ? data : [data]
+    end
   end
 end

--- a/app/graphql/types/bib_data.rb
+++ b/app/graphql/types/bib_data.rb
@@ -1,18 +1,27 @@
 require "graphql"
 require_relative "base_object"
+require_relative "contributor"
+require_relative "copyright"
+require_relative "date"
+require_relative "document_version"
+require_relative "editorial_group"
 
 class Types::BibData < Types::BaseObject
   field :type, String, null: false
   field :title, String, null: true
   field :docidentifier, String, null: true
   field :docnumber, String, null: true
-  field :date, String, null: true
-  field :contributor, String, null: true
+  field :date, Types::Date, null: true
+  field :contributor, [Types::Contributor], null: true
   field :edition, String, null: true
-  field :version, String, null: true
+  field :version, Types::DocumentVersion, null: true
   field :language, String, null: true
   field :script, String, null: true
   field :status, String, null: true
-  field :copyright, String, null: true
-  field :editorialgroup, String, null: true
+  field :copyright, Types::Copyright, null: true
+  field :editorialgroup, Types::EditorialGroup, null: true
+
+  def contributor
+    ensure_array_type(object["contributor"])
+  end
 end

--- a/app/graphql/types/contributor.rb
+++ b/app/graphql/types/contributor.rb
@@ -1,0 +1,6 @@
+require_relative "organization"
+
+class Types::Contributor < Types::BaseObject
+  field :role, String, null: true
+  field :organization, Types::Organization, null: true
+end

--- a/app/graphql/types/copyright.rb
+++ b/app/graphql/types/copyright.rb
@@ -1,0 +1,10 @@
+require_relative "owner"
+
+class Types::Copyright < Types::BaseObject
+  field :from, String, null: true
+  field :owner, Types::Owner, null: true
+
+  def owner
+    object[:owner]
+  end
+end

--- a/app/graphql/types/date.rb
+++ b/app/graphql/types/date.rb
@@ -1,0 +1,4 @@
+class Types::Date < Types::BaseObject
+  field :type, String, null: true
+  field :on, String, null: true
+end

--- a/app/graphql/types/document.rb
+++ b/app/graphql/types/document.rb
@@ -9,15 +9,7 @@ class Types::Document < Types::BaseObject
   field :bibdata, Types::BibData, null: true
   field :termdocsource, String, null: true
   field :preface, String, null: true
-  field :sections, Types::Section, null: false
+  field :sections, Types::Section, null: true
   field :annex, String, null: true
   field :bibliography, String, null: true
-
-  def bibdata
-    object["bibdata"]
-  end
-
-  def sections
-    object["sections"]
-  end
 end

--- a/app/graphql/types/document_version.rb
+++ b/app/graphql/types/document_version.rb
@@ -1,0 +1,3 @@
+class Types::DocumentVersion < Types::BaseObject
+  field :revision_date, String, null: true
+end

--- a/app/graphql/types/editorial_group.rb
+++ b/app/graphql/types/editorial_group.rb
@@ -1,0 +1,3 @@
+class Types::EditorialGroup  < Types::BaseObject
+  field :committee, String, null: true
+end

--- a/app/graphql/types/organization.rb
+++ b/app/graphql/types/organization.rb
@@ -1,0 +1,3 @@
+class Types::Organization < Types::BaseObject
+  field :name, String, null: true
+end

--- a/app/graphql/types/owner.rb
+++ b/app/graphql/types/owner.rb
@@ -1,0 +1,3 @@
+class Types::Owner < Types::BaseObject
+  field :organization, Types::Organization, null: true
+end

--- a/app/graphql/types/section.rb
+++ b/app/graphql/types/section.rb
@@ -4,7 +4,6 @@ class Types::Section < Types::BaseObject
   field :clause, [Types::Clause], null: true
 
   def clause
-    clauses = object["clause"]
-    clauses.is_a?(Array) ? clauses : [clauses]
+    ensure_array_type(object["clause"])
   end
 end

--- a/spec/features/list_documents_spec.rb
+++ b/spec/features/list_documents_spec.rb
@@ -12,6 +12,32 @@ RSpec.describe "List documents" do
             bibdata {
               type
               status
+              contributor {
+                organization {
+                  name
+                }
+              }
+
+              copyright {
+                from
+                owner {
+                  organization {
+                    name
+                  }
+                }
+              }
+
+              date {
+                type
+              }
+
+              version  {
+                revisionDate
+              }
+
+              editorialgroup {
+                committee
+              }
             }
 
             sections  {
@@ -31,6 +57,7 @@ RSpec.describe "List documents" do
       response = JSON.parse(last_response.body)
       documents = response["data"]["documents"]
       sections_clause = documents.first["sections"]["clause"]
+      contributors = documents.first["bibdata"]["contributor"]
 
       expect(documents.size).to eq(1)
       expect(last_response.status).to eq(200)
@@ -39,6 +66,8 @@ RSpec.describe "List documents" do
 
       expect(documents.first["bibdata"]["type"]).to eq("standard")
       expect(documents.first["bibdata"]["status"]).to eq("final-draft")
+      expect(contributors.first["organization"]["name"]).to eq("CalConnect")
+      expect(documents.first["bibdata"]["copyright"]["from"]).to eq("2019")
 
       expect(sections_clause.first["title"]).to eq("Scope")
     end


### PR DESCRIPTION
We have couple of elements in the bibdata note, that we wanted to to serialize properly, so this commit takes that into consideration and then parse those to correct type.

This includes `contributor`, `copyright`, `date`, `version`, `owner` and `editorial_group`.

Fixes #11