### PR TITLE
Parse preface data to queryable node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,9 @@ language: ruby
 rvm:
   - 2.5.1
 
+before_install:
+  - gem install bundler -v 2.0.1
+  - bundle update
+
 cache: bundler
 script: bundle exec rspec

--- a/app/graphql/types/base_object.rb
+++ b/app/graphql/types/base_object.rb
@@ -7,5 +7,10 @@ module Types
     def ensure_array_type(data)
       data.is_a?(Array) ? data : [data]
     end
+
+    def join_paragraphs(paragraphs, connector = "\n")
+      paragraphs = paragraphs
+      paragraphs.is_a?(Array) ? paragraphs.join(connector).to_s : nil
+    end
   end
 end

--- a/app/graphql/types/clause.rb
+++ b/app/graphql/types/clause.rb
@@ -15,7 +15,6 @@ class Types::Clause < Types::BaseObject
   end
 
   def p
-    paragraph = object["p"]
-    paragraph.is_a?(Array) ? paragraph.join("\n").to_s : nil
+    join_paragraphs(object["p"])
   end
 end

--- a/app/graphql/types/document.rb
+++ b/app/graphql/types/document.rb
@@ -2,13 +2,14 @@ require "graphql"
 require_relative "base_object"
 require_relative "bib_data"
 require_relative "section"
+require_relative "preface"
 
 class Types::Document < Types::BaseObject
   field :id, ID, null: false
   field :type, String, null: false
   field :bibdata, Types::BibData, null: true
   field :termdocsource, String, null: true
-  field :preface, String, null: true
+  field :preface, Types::Preface, null: true
   field :sections, Types::Section, null: true
   field :annex, String, null: true
   field :bibliography, String, null: true

--- a/app/graphql/types/foreword.rb
+++ b/app/graphql/types/foreword.rb
@@ -1,0 +1,9 @@
+class Types::Foreword < Types::BaseObject
+  field :p, String, null: true
+  field :title, String, null: true
+  field :obligation, String, null: true
+
+  def p
+    join_paragraphs(object["p"])
+  end
+end

--- a/app/graphql/types/introduction.rb
+++ b/app/graphql/types/introduction.rb
@@ -1,0 +1,9 @@
+class Types::Introduction < Types::BaseObject
+  field :p, String, null: true
+  field :title, String, null: true
+  field :obligation, String, null: true
+
+  def p
+    join_paragraphs(object["p"])
+  end
+end

--- a/app/graphql/types/preface.rb
+++ b/app/graphql/types/preface.rb
@@ -1,0 +1,7 @@
+require_relative "foreword"
+require_relative "introduction"
+
+class Types::Preface < Types::BaseObject
+  field :foreword, Types::Foreword, null: true
+  field :introduction, Types::Introduction, null: true
+end

--- a/app/graphql/types/term_definition.rb
+++ b/app/graphql/types/term_definition.rb
@@ -3,6 +3,5 @@ class Types::Definition < Types::BaseObject
 end
 
 def p
-  paragraph = object["p"]
-  paragraph.is_a?(Array) ? paragraph.join("\n").to_s : nil
+  join_paragraphs(object["p"])
 end

--- a/spec/features/list_documents_spec.rb
+++ b/spec/features/list_documents_spec.rb
@@ -47,7 +47,16 @@ RSpec.describe "List documents" do
             }
 
             termdocsource
-            preface
+            preface {
+              foreword {
+                title
+              }
+
+              introduction {
+                title
+                obligation
+              }
+            }
           }
         }
       MSG


### PR DESCRIPTION
The `preface` node contains some nested data, and this commit adds necessary type, so user can be very specific to select all or part of this data set.

Fixes #8